### PR TITLE
Add link to data access page to footer on Wikidata

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,8 +1,10 @@
 {
 	"@metadata": {
 		"authors": [
-			"Bene*"
+			"Bene*",
+			"Lucie-Aimée Kaffee"
 		]
 	},
-	"wikidata-org-desc": "Configuration for and customizations to Wikibase that are specific to wikidata.org"
+	"wikidata-org-desc": "Configuration for and customizations to Wikibase that are specific to wikidata.org",
+	"wikimedia-developers-url": "Special:MyLanguage/Wiki:Data_access"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,8 +1,10 @@
 {
 	"@metadata": {
 		"authors": [
-			"Bene*"
+			"Bene*",
+			"Lucie-Aimée Kaffee"
 		]
 	},
-	"wikidata-org-desc": "{{desc|name=Wikidata.org|url=https://github.com/wmde/Wikidata.org}}"
+	"wikidata-org-desc": "{{desc|name=Wikidata.org|url=https://github.com/wmde/Wikidata.org}}",
+	"wikimedia-developers-url": "The URL of the data access page on Wikidata."
 }


### PR DESCRIPTION
Overwrites the link to the Wikimedia Developers page

Bug: T85407